### PR TITLE
Update readme to explicitly link to where the releases are

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SketchUp Ruby API Debugger
 This is a Ruby debugger framework for SketchUp 2014 and later. The ruby-debug-ide protocol has been mostly implemented so any Ruby IDE that supports this protocol should work. We have tested with Aptana RadRails, NetBeans (with Ruby community plugin) and RubyMine.
 
 Instructions for Windows:
-- Download the pre-built dynamic library (SURubyDebugger.dll) from the latest release. Copy this DLL into the SketchUp installation directory:
+- Download the pre-built dynamic library (SURubyDebugger.dll) from the [latest release](https://github.com/SketchUp/sketchup-ruby-debugger/releases). Copy this DLL into the SketchUp installation directory:
 ```
 C:\Program Files\SketchUp\SketchUp 2015\
 ```


### PR DESCRIPTION
Hey folks,

I am more used to the intricacies of bitbucket at this point, and it took a frustratingly (ha, emabarassingly? ) long time for me to realize that I needed to click the "Releases" tab in the repo to get to the SURubyDebugger.dll -- hopefully this README.md update will make it clearer!