### PR TITLE
Refactoring RDIP + new features

### DIFF
--- a/Build/postbuild.bat
+++ b/Build/postbuild.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 
 REM Comment/uncomment the next line to control deployment of files to the SketchUp program directory.
-GOTO CopyFiles
+REM GOTO CopyFiles
 
 ECHO postbuild.bat - Skipping deployment of files to the SketchUp program directory.
 GOTO End

--- a/Build/postbuild.bat
+++ b/Build/postbuild.bat
@@ -1,4 +1,35 @@
-rem Comment these out to post-build copy the DLL to SU installation directory.
-rem set SUDIR=C:\Program Files (x86)\SketchUp\SketchUp 2014
-rem xcopy /dy %TARGETDIR%SURubyDebugger.dll %SUDIR%
-rem xcopy /dy %TARGETDIR%SURubyDebugger.pdb %SUDIR%
+@ECHO OFF
+
+REM Comment/uncomment the next line to control deployment of files to the SketchUp program directory.
+GOTO CopyFiles
+
+ECHO postbuild.bat - Skipping deployment of files to the SketchUp program directory.
+GOTO End
+
+:CopyFiles
+ECHO postbuild.bat - Deploying files to the SketchUp program directory.
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+ECHO Locating SketchUp program directory...
+SET SKETCHUP_DIR=
+FOR /D %%i IN ("%PROGRAMW6432%\SketchUp\*") DO SET SKETCHUP_DIR=%%i
+IF [!SKETCHUP_DIR!] == [] GOTO NotFound
+ECHO Found SketchUp program directory: !SKETCHUP_DIR!
+
+ECHO Verifying permissions to copy to SketchUp program directory...
+(ECHO.>"!SKETCHUP_DIR!\.TEST" && (DEL "!SKETCHUP_DIR!\.TEST" & GOTO AccessOkay)) 2>NUL
+ECHO ERROR: You may need elevated permissions to copy to the SketchUp program directory.
+GOTO End
+:AccessOkay
+
+FOR %%i in (SURubyDebugger.dll SURubyDebugger.pdb) DO (
+	ECHO Copying %TARGETDIR%%%i to !SKETCHUP_DIR!...
+	XCOPY /DY "%TARGETDIR%%%i" "!SKETCHUP_DIR!" >NUL 2>&1
+)
+GOTO End
+
+:NotFound
+ECHO ERROR: Could not find SketchUp program directory.
+
+:End

--- a/Common/BreakPoint.h
+++ b/Common/BreakPoint.h
@@ -17,6 +17,7 @@ struct BreakPoint {
   bool enabled;
   std::string file;
   size_t line;
+  std::string condition;
 };
 
 } // end namespace RubyDebugger

--- a/DebugServer/DebuggerSettings.cpp
+++ b/DebugServer/DebuggerSettings.cpp
@@ -36,6 +36,7 @@ static void Save(const BreakPoint& bp, ptree& pt) {
   pt.put("line", bp.line);
   pt.put("index", bp.index);
   pt.put("enabled", bp.enabled);
+  pt.put("condition", bp.condition);
 }
 
 static void Load(const ptree& pt, BreakPoint& bp) {
@@ -43,6 +44,7 @@ static void Load(const ptree& pt, BreakPoint& bp) {
   bp.line = pt.get<size_t>("line");
   bp.index = pt.get<size_t>("index");
   bp.enabled = pt.get<bool>("enabled");
+  bp.condition = pt.get<std::string>("condition");
 }
 
 void SaveBreakPoints(const BreakPointsMap& resolved_bps,

--- a/DebugServer/IDebugServer.h
+++ b/DebugServer/IDebugServer.h
@@ -39,6 +39,15 @@ public:
   // Removes the breakpoint at a given index. Returns true on success.
   virtual bool RemoveBreakPoint(size_t index) = 0;
 
+  // Removes all breakpoints. Returns true on success.
+  virtual bool RemoveAllBreakPoints() = 0;
+
+  // Enables (or disables) the breakpoint at the given index. Returns true on success.
+  virtual bool EnableBreakPoint(size_t index, bool enable) = 0;
+
+  // Sets the condition for the breakpoint at the given index. Returns true on success.
+  virtual bool ConditionBreakPoint(size_t index, const std::string& condition) = 0;
+
   // Returns all breakpoints.
   virtual std::vector<BreakPoint> GetBreakPoints() const = 0;
 

--- a/DebugServer/IDebugServer.h
+++ b/DebugServer/IDebugServer.h
@@ -79,6 +79,9 @@ public:
   // Steps execution out of the current method.
   virtual void StepOut() = 0;
 
+  // Interrupts execution at the first available opportunity.
+  virtual void Pause() = 0;
+
   // Returns the code lines around the current line. Execution must have stopped.
   virtual std::vector<std::pair<size_t, std::string>>
       GetCodeLines(size_t beg_line, size_t end_line) const = 0;

--- a/DebugServer/Log.h
+++ b/DebugServer/Log.h
@@ -1,17 +1,77 @@
 // SketchUp Ruby API Debugger. Copyright 2013 Trimble Navigation Ltd.
 // Authors:
 // - Bugra Barin
+// - Aaron Hill (@Seraku) - Enhanced logging function.
 //
 #pragma once
+
+#include <chrono>
+#include <iomanip>
+#include <regex>
+#include <sstream>
+#include <string>
 
 namespace SketchUp {
 namespace RubyDebugger {
 
-inline void Log(const char* str) {
+namespace Log {
+
+static inline std::string Context(const char *filename, size_t line, const char *function) {
+  std::ostringstream output;
+
+  static auto start_time = std::chrono::high_resolution_clock::now();
+  auto current_time = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(current_time - start_time).count() * 0.000001;
+  output << std::fixed << std::setprecision(4) << elapsed << '\t';
+
+  int thread_id = 0;
 #ifdef WIN32
-  OutputDebugStringA(str);
+  thread_id = static_cast<int>(GetCurrentThreadId());
+#else
+  //thread_id = pthread_getthreadid_np();
 #endif
+  output << '[' << std::dec << thread_id << "]\t";
+
+  if (filename) {
+    static const std::regex filename_regex("[^/\\\\]+$");
+    std::cmatch match;
+    if (std::regex_search(filename, match, filename_regex)) {
+      output << match.str() << ':' << std::dec << line << '\t';
+    }
+  }
+  if (function) {
+    static const std::regex function_regex("[^:]+$");
+    std::cmatch match;
+    if (std::regex_search(function, match, function_regex)) {
+      output << match.str() << "()\t";
+    }
+  }
+
+  return output.str();
 }
+
+#ifdef _DEBUG
+#define LOG_CONTEXT (SketchUp::RubyDebugger::Log::Context(__FILE__, __LINE__, __FUNCTION__))
+#else
+#define LOG_CONTEXT (SketchUp::RubyDebugger::Log::Context(nullptr, 0, nullptr))
+#endif
+
+static inline void Write(const std::string &context, const std::string &message) {
+  static const std::regex newline_regex("[\r\n]+");
+  static const std::sregex_token_iterator end;
+  for (std::sregex_token_iterator iter(message.begin(), message.end(), newline_regex, -1); iter != end; ++iter) {
+#ifdef WIN32
+    OutputDebugStringA((context + iter->str() + "\r\n").c_str());
+#else
+    std::cout << context << iter->str() << std::endl;
+#endif
+  }
+}
+
+#define LOG(msg) (SketchUp::RubyDebugger::Log::Write(LOG_CONTEXT, (msg)))
+#define FMT(msg) ([=](){ std::ostringstream oss; (oss << msg); return oss.str(); }())
+
+} // end namespace Log
 
 } // end namespace RubyDebugger
 } // end namespace SketchUp

--- a/DebugServer/Log.h
+++ b/DebugServer/Log.h
@@ -60,10 +60,14 @@ static inline void Write(const std::string &context, const std::string &message)
   static const std::regex newline_regex("[\r\n]+");
   static const std::sregex_token_iterator end;
   for (std::sregex_token_iterator iter(message.begin(), message.end(), newline_regex, -1); iter != end; ++iter) {
+    const int line_length_limit = 4000;
+    std::string line = context + iter->str();
+    if (line.length() > line_length_limit) line = line.substr(0, line_length_limit);
+
 #ifdef WIN32
-    OutputDebugStringA((context + iter->str() + "\r\n").c_str());
+    OutputDebugStringA((line + "\r\n").c_str());
 #else
-    std::cout << context << iter->str() << std::endl;
+    std::cout << line << std::endl;
 #endif
   }
 }

--- a/DebugServer/Server.h
+++ b/DebugServer/Server.h
@@ -27,6 +27,12 @@ public:
 
   virtual bool RemoveBreakPoint(size_t index);
 
+  virtual bool RemoveAllBreakPoints();
+
+  virtual bool EnableBreakPoint(size_t index, bool enable);
+
+  virtual bool ConditionBreakPoint(size_t index, const std::string& condition);
+
   virtual std::vector<BreakPoint> GetBreakPoints() const;
 
   virtual bool IsStopped() const;

--- a/DebugServer/Server.h
+++ b/DebugServer/Server.h
@@ -13,7 +13,7 @@
 namespace SketchUp {
 namespace RubyDebugger {
 
-// Debugger server implementation 
+// Debugger server implementation
 class Server : public IDebugServer {
 public:
 

--- a/DebugServer/Server.h
+++ b/DebugServer/Server.h
@@ -53,6 +53,8 @@ public:
 
   virtual void StepOut();
 
+  virtual void Pause();
+
   virtual std::vector<std::pair<size_t, std::string>>
       GetCodeLines(size_t beg_line, size_t end_line) const;
 

--- a/DebugServer/UI/RDIP/RDIP.cpp
+++ b/DebugServer/UI/RDIP/RDIP.cpp
@@ -205,8 +205,8 @@ void RDIP::Impl::evaluateCommand(const std::string &command) {
   // This represents only a subset of all commands defined by ruby-debug-ide.
   //
   // For reference, here are the commands that are not yet supported:
-  //    catch, restart, interrupt, detach, pp, expression_info,
-  //    include, exclude, file-filter, up, down, jump, load, pause,
+  //    catch, restart, detach, pp, expression_info,
+  //    include, exclude, file-filter, up, down, jump, load,
   //    set_type, thread switch, thread inspect, thread stop,
   //    thread current, thread resume, var constant
 
@@ -267,6 +267,7 @@ void RDIP::Impl::evaluateCommand(const std::string &command) {
   static const std::regex continue_regex("^c(?:ont)?$", std::regex_constants::icase);
   static const std::regex finish_regex("^fin(?:ish)?$", std::regex_constants::icase);
   static const std::regex next_regex("^n(?:ext)?$", std::regex_constants::icase);
+  static const std::regex pause_regex("^(?:pause|i(?:nterrupt)?)$", std::regex_constants::icase);
   static const std::regex quit_regex("^(?:q(?:uit)?|exit)$", std::regex_constants::icase);
   static const std::regex start_regex("^start$", std::regex_constants::icase);
   static const std::regex step_regex("^s(?:tep)?$", std::regex_constants::icase);
@@ -279,6 +280,8 @@ void RDIP::Impl::evaluateCommand(const std::string &command) {
   } else if (std::regex_match(command, match, next_regex)) {
     server_->StepOver();
     notifyWait(true);
+  } else if (std::regex_match(command, match, pause_regex)) {
+    server_->Pause();
   } else if (std::regex_match(command, match, quit_regex)) {
     notifyWait(true);
     closeConnection();

--- a/DebugServer/UI/RDIP/RDIP.cpp
+++ b/DebugServer/UI/RDIP/RDIP.cpp
@@ -380,10 +380,10 @@ void RDIP::Impl::sendResponse(const std::string &response) {
   str.append("\r\n");
 
   if (socket_.is_open()) {
-    LOG(FMT("Sending response to ruby-debug-ide client:\r\n" << str));
+    LOG(FMT("Sending response to ruby-debug-ide client:\r\n" << str.substr(0, 4000)));
     boost::asio::write(socket_, boost::asio::buffer(str));
   } else {
-    LOG(FMT("No ruby-debug-ide client connected.  Unable to send response:\r\n" << str));
+    LOG(FMT("No ruby-debug-ide client connected.  Unable to send response:\r\n" << str.substr(0, 4000)));
   }
 }
 

--- a/DebugServer/UI/RDIP/RDIP.h
+++ b/DebugServer/UI/RDIP/RDIP.h
@@ -2,20 +2,14 @@
 // Authors:
 // - Orhun Birsoy
 // - Bugra Barin
+// - Aaron Hill (@Seraku) - Refactored ruby-debug-ide protocol implementation.
 //
 #ifndef RDEBUGGER_DEBUGSERVER_UI_CONSOLE_WIN_RDIP_H_
 #define RDEBUGGER_DEBUGSERVER_UI_CONSOLE_WIN_RDIP_H_
 
 #include <DebugServer/UI/IDebuggerUI.h>
 
-#include <atomic>
-#include <functional>
-#include <condition_variable>
-#include <mutex>
-#include <thread>
-
-#include <boost/asio/io_service.hpp>
-#include <boost/asio/signal_set.hpp>
+#include <memory>
 
 namespace SketchUp {
 namespace RubyDebugger {
@@ -28,33 +22,19 @@ public:
 
   virtual void Initialize(IDebugServer* server,
                           const std::string& str_debugger);
-
+  
   virtual bool IsIDE() { return true; }
-
+  
   virtual void WaitForContinue();
-
+  
   virtual void Break(BreakPoint bp);
-
+  
   virtual void Break(const std::string& file, size_t line);
 
 private:
-    class Connection;
-
-    void RunService(int port);
-    void HandleFatalFailure(const boost::system::error_code& err, int signal);
-    void HandleConnection(const boost::system::error_code& err);
-
-private:
-    boost::asio::io_service io_service_;
-    boost::asio::signal_set signal_set_;
-    std::thread service_thread_;
-    std::condition_variable server_wait_cond_;
-    std::mutex server_wait_mutex_;
-    bool server_can_continue_;
-
-    std::shared_ptr<Connection> connection_;
-    std::function<void(void)> server_response_;
-    std::function<void(void)> process_server_response_;
+  class Impl;
+  std::shared_ptr<Impl> impl_;
+  bool wait_for_client_;
 };
 
 } // end namespace RubyDebugger

--- a/DebugServer/UI/RDIP/RDIP.h
+++ b/DebugServer/UI/RDIP/RDIP.h
@@ -22,13 +22,13 @@ public:
 
   virtual void Initialize(IDebugServer* server,
                           const std::string& str_debugger);
-  
+
   virtual bool IsIDE() { return true; }
-  
+
   virtual void WaitForContinue();
-  
+
   virtual void Break(BreakPoint bp);
-  
+
   virtual void Break(const std::string& file, size_t line);
 
 private:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ SketchUp Ruby API Debugger
 
 This is a Ruby debugger framework for SketchUp 2014 and later. The `ruby-debug-ide` protocol has been mostly implemented so any Ruby IDE that supports this protocol should work.
 
-| IDE | Stable (1.0.3.0) | Latest (pre-release)
-| - | - | - |
+| IDE | Stable (1.0.3.0) | Latest (pre-release) |
+| --- | --- | --- |
 | Aptana RadRails | Good | *Untested* |
 | NetBeans (with Ruby community plugin) | Good | *Untested* |
 | RubyMine | Good | Testing in progress |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When launching SketchUp with debugging enabled, the following command-line argum
 
 - `port=<number>` - Configures the port on which the SketchUp debugger accepts connections from IDEs. This must match the remote debugger port setting configured in the IDE. If not specified, the port defaults to **1234**.
 
-- `wait` - Instructs the SketchUp debugger to wait for an initial connection from an IDE before allowing execution to continue. This is necessary to debug scripts that run automatically, for instance when an extention is loaded. When using this option, the SketchUp process will appear to be frozen until an IDE is attached.
+- `wait` - Instructs the SketchUp debugger to wait for an initial connection from an IDE before allowing execution to continue. This is necessary to debug scripts that run automatically, for instance when an extension is loaded. When using this option, the SketchUp process will appear to be frozen until an IDE is attached.
 
 ## Notes:
 While most common debugging functionality has been implemented, there are few TODOs:

--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
 SketchUp Ruby API Debugger
 ==========================
 
-This is a Ruby debugger framework for SketchUp 2014 and later. The ruby-debug-ide protocol has been mostly implemented so any Ruby IDE that supports this protocol should work. We have tested with Aptana RadRails, NetBeans (with Ruby community plugin) and RubyMine.
+This is a Ruby debugger framework for SketchUp 2014 and later. The `ruby-debug-ide` protocol has been mostly implemented so any Ruby IDE that supports this protocol should work.
 
-Instructions for Windows:
-- Download the pre-built dynamic library (SURubyDebugger.dll) from the [latest release](https://github.com/SketchUp/sketchup-ruby-debugger/releases). Copy this DLL into the SketchUp installation directory:
+| IDE | Stable (1.0.3.0) | Latest (pre-release)
+| - | - | - |
+| Aptana RadRails | Good | *Untested* |
+| NetBeans (with Ruby community plugin) | Good | *Untested* |
+| RubyMine | Good | Testing in progress |
+| VS Code (with `vscode-ruby` extension) | Not supported | Testing in progress |
+
+## Instructions for Windows:
+- Download the pre-built dynamic library (SURubyDebugger.dll) from the [latest release](https://github.com/SketchUp/sketchup-ruby-debugger/releases) or build from the sources.
+- Copy the DLL into the SketchUp installation directory. As the exact path will depend on the version of SketchUp you have installed, look for a folder similar to the following:
 ```
-C:\Program Files\SketchUp\SketchUp 2015\
-```
-or for 32-bit SketchUp (including SketchUp 2014):
-```
+C:\Program Files\SketchUp\SketchUp 2017\
+
 C:\Program Files (x86)\SketchUp\SketchUp 2015\
 ```
-- Run SketchUp with the following command line arguments:
+- Start SketchUp from the command line or the "Run..." dialog:
 ```
 SketchUp.exe -rdebug "ide port=7000"
 ```
 
-Instructions for Mac OS X:
-- Install SketchUp 2014 Maintenance 1 Release (version 14.1.1283) or later
+## Instructions for Mac OS X:
+- Install SketchUp 2014 Maintenance 1 Release (version 14.1.1283) or later.
 - Download SURubyDebugger.dylib into the Frameworks directory of the app bundle:
 ```
 curl https://github.com/SketchUp/sketchup-ruby-debugger/releases/download/1.0.3.0/SURubyDebugger.dylib -o /Applications/SketchUp\ 2017/SketchUp.app/Contents/Frameworks/SURubyDebugger.dylib
@@ -28,17 +34,23 @@ curl https://github.com/SketchUp/sketchup-ruby-debugger/releases/download/1.0.3.
 open -a /Applications/SketchUp\ 2015/SketchUp.app --args -rdebug "ide port=7000"
 ```
 
-Notes:
-- The port should match the remote debugger port setting configured in the IDE. Default port is 1234.
-- SketchUp will start up and appear to be frozen. It is waiting for the debugger to show up.
-- Launch remote debugging in the IDE, SketchUp should continue running. You should see breakpoints hit when Ruby code execution reaches the specified lines.
+## Command-line arguments:
+When launching SketchUp with debugging enabled, the following command-line arguments are supported:
 
+```
+-rdebug "ide [port=<number>] [wait]"
+```
 
-Most common debugging functionality has been implemented but there are few TODOs:
+- `port=<number>` - Configures the port on which the SketchUp debugger accepts connections from IDEs. This must match the remote debugger port setting configured in the IDE. If not specified, the port defaults to **1234**.
+
+- `wait` - Instructs the SketchUp debugger to wait for an initial connection from an IDE before allowing execution to continue. This is necessary to debug scripts that run automatically, for instance when an extention is loaded. When using this option, the SketchUp process will appear to be frozen until an IDE is attached.
+
+## Notes:
+While most common debugging functionality has been implemented, there are few TODOs:
 - Debugging of multi-threaded execution
+- Function breakpoints
 - Exception breakpoints
-- Conditional breakpoints
-- What else are we missing ? Please report and contribute!
+- *Are we missing something else?* Please report and contribute!
 
 To contribute, please fork the repository, make your changes and submit a pull request.
 


### PR DESCRIPTION
__*Whew!*__ I believe this is my biggest contribution to any github project to date.  Here's hoping that it works for folks.  `(:`

While the commit message lists all of the changes, here are a few highlights:

### Proper handling of cross-thread work.  (Fixes #10.)
The coordination between the main debugger thread and the I/O service thread has been improved.

### Improved attach/detach logic.  (Fixes #7.)
IDEs can attach to SketchUp at any time, even after stopping a previous debugging session.  There is better handling of errors, allowing the SketchUp process to resume execution if the connection to the IDE is lost.  Additionally, the SketchUp process no longer hangs at launch by default.

To enable debugging of scripts that run automatically (i.e. extensions), a new command-line argument, `wait`, may optionally be specified to force SketchUp to wait until a debugger client has attached.

`SketchUp -rdebug "ide port=1234 wait"`

### Conditional breakpoints supported.
This was a relatively easy item to add, building on top of the code for evaluating arbitrary expressions.

NOTE: The current version of `vscode-ruby` only has preliminary support for conditional breakpoints, and as such it requires a few code changes to fully enable it.

---

@thomthom, @BugraB When you are able, I would greatly appreciate your time and help reviewing the code as well as testing the proposed changes on different systems.